### PR TITLE
Adopt change points offset convention from `ruptures`

### DIFF
--- a/src/tamis/_tamis/ebcd.pyx
+++ b/src/tamis/_tamis/ebcd.pyx
@@ -16,9 +16,14 @@ cpdef ebcd_core(double[:, :] signal, double[:] weights, double lbd, double tol=D
         cdef double[::1] weights_arr = np.ascontiguousarray(weights)
 
     ebcd.ebcd_compute(&signal_arr[0, 0], n_samples, n_dims, lbd, &weights_arr[0], tol, &res)
-    A_list = [el for el in res.A[:res.n_A]]
+
+    # Construct change points to be returned
+    A_list = [el+1 for el in res.A[:res.n_A]]
     A_arr = np.sort(A_list)
-    A_arr = np.append(A_arr, [signal.shape[0]-1])
+    A_arr = np.append(A_arr, [signal.shape[0]])
+
+    # Construct the approximate signal to be returned
     U_list = [el for el in res.U[:n_samples*n_dims]]
     U_arr = np.array(U_list).reshape((n_samples, n_dims))
+
     return res.n_A, A_arr, U_arr


### PR DESCRIPTION
In `ruptures`, if a change point is `c_bkp`, then it means that point at index `c_bkp-1` belongs to segment `s` and point at index `c_bkp` belongs to the segment `s+1`.
<img width="371" alt="Screenshot 2021-07-02 at 14 39 11" src="https://user-images.githubusercontent.com/12909374/124275783-4d3bf980-db43-11eb-89e6-f65966dded38.png">

Whereas in the paper `Bleakley and Vert (2011)`, if `i` is in the active set, then it means that point at index `i` belongs to segment `s ` and point at index `i+1` belongs to segment `s+1`
<img width="328" alt="Screenshot 2021-07-02 at 14 39 52" src="https://user-images.githubusercontent.com/12909374/124275859-62b12380-db43-11eb-9372-4f1309d65b45.png">

This PR fixes the translation between the two conventions. 